### PR TITLE
fix: webpack.config remove unused 'async-props'

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -12,7 +12,6 @@ const port = parseInt(process.env.PORT, 10) + 1 || 3001;
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 const vendor = [
-  'async-props',
   'lodash',
   'react',
   'react-dom',


### PR DESCRIPTION
 'async-props' was switched to 'redux-async-connect' so now it was showing error of module not found  'async-props' when building.
