### PR TITLE
feat: add support for customizing root components

### DIFF
--- a/bin/merge-configs.js
+++ b/bin/merge-configs.js
@@ -83,13 +83,18 @@ module.exports = (userConfig) => {
   lodash.each(universalReduxConfig.globals, (value, key) => { definitions[key] = JSON.stringify(value); });
   combinedWebpackConfig.plugins.push(new webpack.DefinePlugin(definitions));
 
-  // add routes and reducer aliases so that client has access to them
+  // add routes, reducer and rootComponent aliases so that client has access to them
   combinedWebpackConfig.resolve.alias = combinedWebpackConfig.resolve.alias || {};
   combinedWebpackConfig.resolve.alias.routes = universalReduxConfig.routes;
   if (universalReduxConfig.redux.middleware) {
     combinedWebpackConfig.resolve.alias.middleware = universalReduxConfig.redux.middleware;
   } else {
     combinedWebpackConfig.resolve.alias.middleware = path.resolve(__dirname, '../lib/helpers/empty.js');
+  }
+  if(universalReduxConfig.rootComponent){
+    combinedWebpackConfig.resolve.alias.rootComponent = universalReduxConfig.rootComponent;
+  } else {
+    combinedWebpackConfig.resolve.alias.rootComponent = path.resolve(__dirname, '../lib/helpers/rootComponent.js');
   }
 
   // add project level vendor libs

--- a/bin/merge-configs.js
+++ b/bin/merge-configs.js
@@ -91,7 +91,7 @@ module.exports = (userConfig) => {
   } else {
     combinedWebpackConfig.resolve.alias.middleware = path.resolve(__dirname, '../lib/helpers/empty.js');
   }
-  if(universalReduxConfig.rootComponent){
+  if (universalReduxConfig.rootComponent) {
     combinedWebpackConfig.resolve.alias.rootComponent = universalReduxConfig.rootComponent;
   } else {
     combinedWebpackConfig.resolve.alias.rootComponent = path.resolve(__dirname, '../lib/helpers/rootComponent.js');

--- a/config/universal-redux.config.js
+++ b/config/universal-redux.config.js
@@ -125,7 +125,7 @@ module.exports = (projectRoot, sourceRoot) => {
     /*
     // The root component factory file. Optional. Will be added to Webpack aliases.
     */
-    //rootComponent: sourceRoot + '/rootComponent.js',
+    // rootComponent: sourceRoot + '/rootComponent.js',
 
     html: {
       /*

--- a/config/universal-redux.config.js
+++ b/config/universal-redux.config.js
@@ -122,6 +122,11 @@ module.exports = (projectRoot, sourceRoot) => {
     */
     routes: sourceRoot + '/routes.js',
 
+    /*
+    // The root component factory file. Optional. Will be added to Webpack aliases.
+    */
+    //rootComponent: sourceRoot + '/rootComponent.js',
+
     html: {
       /*
       // A path to a component that provides additional DOM items to be appended

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-transform-hmr": "1.0.1",
     "redbox-react": "1.2.0",
     "redux": "3.0.5",
-    "redux-async-connect": "0.1.3",
+    "redux-async-connect": "0.1.9",
     "redux-devtools": "3.0.1",
     "redux-devtools-dock-monitor": "1.0.1",
     "redux-devtools-log-monitor": "1.0.2",

--- a/src/client.js
+++ b/src/client.js
@@ -9,7 +9,7 @@ import { render as renderDevtools } from './client/devtools';
 // as assigned in merge-configs.js
 import getRoutes from 'routes';
 import middleware from 'middleware';
-import {createForClient as createRootComponentForClient } from 'rootComponent';
+import { createForClient as createRootComponentForClient } from 'rootComponent';
 
 const dest = document.getElementById('content');
 
@@ -18,8 +18,8 @@ const routes = getRoutes(store);
 const devComponent = renderDevtools();
 
 // There is probably no need to be asynchronous here
-createRootComponentForClient(store, {routes, history})
-  .then(({root}) => {
+createRootComponentForClient(store, { routes, history })
+  .then(({ root }) => {
     ReactDOM.render(root, dest);
 
     if (process.env.NODE_ENV !== 'production') {
@@ -29,9 +29,9 @@ createRootComponentForClient(store, {routes, history})
       }
     }
 
-    return devComponent ? createRootComponentForClient(store, {routes, history, devComponent}) : {};
+    return devComponent ? createRootComponentForClient(store, { routes, history, devComponent }) : {};
   })
-  .then(({root}) => {
+  .then(({ root }) => {
     if (root) ReactDOM.render(root, dest);
   })
   .catch((err) => {

--- a/src/client.js
+++ b/src/client.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Provider } from 'react-redux';
-import { Router, browserHistory } from 'react-router';
+import { browserHistory as history } from 'react-router';
 
-import { ReduxAsyncConnect } from 'redux-async-connect';
 import createStore from './shared/create';
 import { render as renderDevtools } from './client/devtools';
 
@@ -11,29 +9,31 @@ import { render as renderDevtools } from './client/devtools';
 // as assigned in merge-configs.js
 import getRoutes from 'routes';
 import middleware from 'middleware';
+import {createForClient as createRootComponentForClient } from 'rootComponent';
 
 const dest = document.getElementById('content');
-const store = createStore(middleware, browserHistory, window.__data);
 
-const component = (
-  <Router render={(props) => <ReduxAsyncConnect {...props}/>} history={browserHistory}>
-    {getRoutes(store)}
-  </Router>
-);
+const store = createStore(middleware, history, window.__data);
+const routes = getRoutes(store);
+const devComponent = renderDevtools();
 
-ReactDOM.render(
-  <Provider store={store} key="provider">
-    {component}
-  </Provider>,
-  dest
-);
+//There is probably no need to be asynchronous here
+createRootComponentForClient(store, {routes, history})
+  .then(({root, component}) => {
+    ReactDOM.render(root, dest);
 
-if (process.env.NODE_ENV !== 'production') {
-  window.React = React; // enable debugger
+    if (process.env.NODE_ENV !== 'production') {
+      window.React = React; // enable debugger
+      if (!dest || !dest.firstChild || !dest.firstChild.attributes || !dest.firstChild.attributes['data-react-checksum']) {
+        throw new Error('Server-side React render was discarded. Make sure that your initial render does not contain any client-side code.');
+      }
+    }
 
-  if (!dest || !dest.firstChild || !dest.firstChild.attributes || !dest.firstChild.attributes['data-react-checksum']) {
-    console.error('Server-side React render was discarded. Make sure that your initial render does not contain any client-side code.');
-  }
-}
-
-renderDevtools(component, store, dest);
+    return devComponent ? createRootComponentForClient(store, {routes, history, devComponent}) : {};
+  })
+  .then(({root}) => {
+    if(root) ReactDOM.render(root, dest);
+  })
+  .catch((err) => {
+    console.error(err, err.stack);
+  });

--- a/src/client.js
+++ b/src/client.js
@@ -17,9 +17,9 @@ const store = createStore(middleware, history, window.__data);
 const routes = getRoutes(store);
 const devComponent = renderDevtools();
 
-//There is probably no need to be asynchronous here
+// There is probably no need to be asynchronous here
 createRootComponentForClient(store, {routes, history})
-  .then(({root, component}) => {
+  .then(({root}) => {
     ReactDOM.render(root, dest);
 
     if (process.env.NODE_ENV !== 'production') {
@@ -32,7 +32,7 @@ createRootComponentForClient(store, {routes, history})
     return devComponent ? createRootComponentForClient(store, {routes, history, devComponent}) : {};
   })
   .then(({root}) => {
-    if(root) ReactDOM.render(root, dest);
+    if (root) ReactDOM.render(root, dest);
   })
   .catch((err) => {
     console.error(err, err.stack);

--- a/src/client/devtools.js
+++ b/src/client/devtools.js
@@ -1,6 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import { Provider } from 'react-redux';
 import { compose as _compose, applyMiddleware } from 'redux';
 import { createDevTools, persistState } from 'redux-devtools';
 
@@ -37,6 +35,6 @@ export function listenToRouter(routerMiddleware, store) {
 export function render() {
   if (__DEVTOOLS__ && !window.devToolsExtension) {
     const Tools = __DEVTOOLS_IS_VISIBLE__ ? DevTools : InvisibleDevTools;
-    return <Tools />
+    return <Tools />;
   }
 }

--- a/src/client/devtools.js
+++ b/src/client/devtools.js
@@ -34,17 +34,9 @@ export function listenToRouter(routerMiddleware, store) {
   routerMiddleware.listenForReplays(store);
 }
 
-export function render(component, store, dest) {
+export function render() {
   if (__DEVTOOLS__ && !window.devToolsExtension) {
     const Tools = __DEVTOOLS_IS_VISIBLE__ ? DevTools : InvisibleDevTools;
-    ReactDOM.render(
-      <Provider store={store} key="provider">
-        <div>
-          {component}
-          <Tools />
-        </div>
-      </Provider>,
-      dest
-    );
+    return <Tools />
   }
 }

--- a/src/helpers/rootComponent.js
+++ b/src/helpers/rootComponent.js
@@ -1,16 +1,25 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { RouterContext, Router } from 'react-router';
+import { Router } from 'react-router';
+import { ReduxAsyncConnect, loadOnServer } from 'redux-async-connect';
 
 export function createForServer(store, renderProps) {
-  const root = (
-    <Provider store={store} key="provider">
-      <div>
-        <RouterContext {...renderProps} />
-      </div>
-    </Provider>
-  );
-  return Promise.resolve({root});
+  return new Promise((resolve, reject) => {
+    loadOnServer(renderProps, store)
+      .then(() => {
+        const root = (
+          <Provider store={store} key="provider">
+            <div>
+              <ReduxAsyncConnect {...renderProps} />
+            </div>
+          </Provider>
+        );
+        resolve({ root });
+      })
+      .catch((err) => {
+        reject(err);
+      });
+  });
 }
 
 export function createForClient(store, {routes, history, devComponent}) {

--- a/src/helpers/rootComponent.js
+++ b/src/helpers/rootComponent.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { RouterContext, Router } from 'react-router';
 
-export function createForServer(store, renderProps){
+export function createForServer(store, renderProps) {
   const root = (
     <Provider store={store} key="provider">
       <div>
@@ -13,7 +13,7 @@ export function createForServer(store, renderProps){
   return Promise.resolve({root});
 }
 
-export function createForClient(store, {routes, history, devComponent}){
+export function createForClient(store, {routes, history, devComponent}) {
   const component = (
     <Router history={history}>
       {routes}
@@ -30,5 +30,3 @@ export function createForClient(store, {routes, history, devComponent}){
 
   return Promise.resolve({root});
 }
-
-

--- a/src/helpers/rootComponent.js
+++ b/src/helpers/rootComponent.js
@@ -22,7 +22,7 @@ export function createForServer(store, renderProps) {
   });
 }
 
-export function createForClient(store, {routes, history, devComponent}) {
+export function createForClient(store, { routes, history, devComponent }) {
   const component = (
     <Router history={history}>
       {routes}
@@ -37,5 +37,5 @@ export function createForClient(store, {routes, history, devComponent}) {
     </Provider>
   );
 
-  return Promise.resolve({root});
+  return Promise.resolve({ root });
 }

--- a/src/helpers/rootComponent.js
+++ b/src/helpers/rootComponent.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { RouterContext, Router } from 'react-router';
+
+export function createForServer(store, renderProps){
+  const root = (
+    <Provider store={store} key="provider">
+      <div>
+        <RouterContext {...renderProps} />
+      </div>
+    </Provider>
+  );
+  return Promise.resolve({root});
+}
+
+export function createForClient(store, {routes, history, devComponent}){
+  const component = (
+    <Router history={history}>
+      {routes}
+    </Router>
+  );
+  const root = (
+    <Provider store={store} key="provider">
+      <div>
+        {component}
+        {devComponent}
+      </div>
+    </Provider>
+  );
+
+  return Promise.resolve({root});
+}
+
+

--- a/src/server/renderer.js
+++ b/src/server/renderer.js
@@ -1,5 +1,4 @@
 import path from 'path';
-import React from 'react';
 import { match } from 'react-router';
 import PrettyError from 'pretty-error';
 import createMemoryHistory from 'react-router/lib/createMemoryHistory';
@@ -18,7 +17,7 @@ export default (projectConfig, projectToolsConfig) => {
   const tools = getTools(projectConfig, projectToolsConfig);
   const config = configure(projectConfig);
   const getRoutes = require(path.resolve(config.routes)).default;
-  const rootComponent = require(config.rootComponent ? path.resolve(config.rootComponent) : '../helpers/rootComponent') ;
+  const rootComponent = require(config.rootComponent ? path.resolve(config.rootComponent) : '../helpers/rootComponent');
   const pretty = new PrettyError();
 
   return (req, res) => {

--- a/src/server/renderer.js
+++ b/src/server/renderer.js
@@ -43,7 +43,7 @@ export default (projectConfig, projectToolsConfig) => {
           res.status(500);
         } else if (renderProps) {
           rootComponent.createForServer(store, renderProps)
-            .then(({root}) => {
+            .then(({ root }) => {
               const content = html(config, tools.assets(), store, res._headers, root);
               res.status(200).send(content);
             })


### PR DESCRIPTION
This PR adds support for customizing the rendering of the root components. It works by defining a rootComponent path in the config file which points to a file that defines functions for rendering the server/client root components. I think it takes care of bdefore/universal-redux#48 but I'm not familiar enough with Relay/Falcor to be sure. 

For now the rootComponent.js included in this PR does not support any form of async loading. It would be easy to update it to use [Rezonans/redux-async-connect](https://github.com/Rezonans/redux-async-connect) if you want to support async loading by default. Let me know if that's something you would like me to do.

If you are curious, here is a [gist](https://gist.github.com/aam229/2431c99fcad1f2e291c2) for a custom async loading solution that fits my need but I'm not suggesting we use it by default. 

Please let me know what you think!
