### PR TITLE
started work on redux-async-connect helpers

### DIFF
--- a/bin/merge-configs.js
+++ b/bin/merge-configs.js
@@ -77,6 +77,8 @@ module.exports = (userConfig) => {
   combinedWebpackConfig.resolve.alias['universal-redux/middleware'] = universalReduxConfig.redux.middleware || path.resolve(__dirname, '../lib/helpers/empty.js');
   const rootComponentPath = universalReduxConfig.rootClientComponent || universalReduxConfig.rootComponent || path.resolve(__dirname, '../lib/client/root.js');
   combinedWebpackConfig.resolve.alias['universal-redux/rootClientComponent'] = rootComponentPath;
+  console.log('merge configs', universalReduxConfig.reduxAsyncConnect.helpers);
+  console.log('merge configs', universalReduxConfig);
   combinedWebpackConfig.resolve.alias['universal-redux/asyncHelpers'] = universalReduxConfig.reduxAsyncConnect.helpers || path.resolve(__dirname, '../lib/helpers/emptyFunction.js');
 
   // add project level vendor libs

--- a/bin/merge-configs.js
+++ b/bin/merge-configs.js
@@ -77,8 +77,6 @@ module.exports = (userConfig) => {
   combinedWebpackConfig.resolve.alias['universal-redux/middleware'] = universalReduxConfig.redux.middleware || path.resolve(__dirname, '../lib/helpers/empty.js');
   const rootComponentPath = universalReduxConfig.rootClientComponent || universalReduxConfig.rootComponent || path.resolve(__dirname, '../lib/client/root.js');
   combinedWebpackConfig.resolve.alias['universal-redux/rootClientComponent'] = rootComponentPath;
-  console.log('merge configs', universalReduxConfig.reduxAsyncConnect.helpers);
-  console.log('merge configs', universalReduxConfig);
   combinedWebpackConfig.resolve.alias['universal-redux/asyncHelpers'] = universalReduxConfig.reduxAsyncConnect.helpers || path.resolve(__dirname, '../lib/helpers/emptyFunction.js');
 
   // add project level vendor libs

--- a/bin/merge-configs.js
+++ b/bin/merge-configs.js
@@ -71,12 +71,13 @@ module.exports = (userConfig) => {
     combinedWebpackConfig.plugins.push(new WebpackErrorNotificationPlugin());
   }
 
-  // add routes, reducer and rootClientComponent aliases so that client has access to them
+  // add routes, reducer, asyncHelpers and rootClientComponent aliases so that client has access to them
   combinedWebpackConfig.resolve.alias = combinedWebpackConfig.resolve.alias || {};
   combinedWebpackConfig.resolve.alias['universal-redux/routes'] = universalReduxConfig.routes;
   combinedWebpackConfig.resolve.alias['universal-redux/middleware'] = universalReduxConfig.redux.middleware || path.resolve(__dirname, '../lib/helpers/empty.js');
   const rootComponentPath = universalReduxConfig.rootClientComponent || universalReduxConfig.rootComponent || path.resolve(__dirname, '../lib/client/root.js');
   combinedWebpackConfig.resolve.alias['universal-redux/rootClientComponent'] = rootComponentPath;
+  combinedWebpackConfig.resolve.alias['universal-redux/asyncHelpers'] = universalReduxConfig.reduxAsyncConnect.helpers || path.resolve(__dirname, '../lib/helpers/emptyFunction.js');
 
   // add project level vendor libs
   if (universalReduxConfig.webpack.vendorLibraries && isProduction) {

--- a/config/universal-redux.config.js
+++ b/config/universal-redux.config.js
@@ -202,7 +202,18 @@ module.exports = {
     //
     // Expects: String
     */
-    middleware: sourceRoot + '/redux/middleware/index.js',
+    middleware: sourceRoot + '/redux/middleware/index.js'
+  },
+
+  reduxAsyncConnect: {
+
+    /*
+    // Additional helpers available to 'redux-async-connect'
+    // see
+    // https://github.com/Rezonans/redux-async-connect/blob/master/docs/API.MD#helpers
+    // for usage
+    */
+    // helpers: sourceRoot + '/helpers/index.js'
   },
 
   /*

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-transform-hmr": "1.0.2",
     "redbox-react": "1.2.2",
     "redux": "3.3.1",
-    "redux-async-connect": "0.1.13",
+    "redux-async-connect": "1.0.0-rc2",
     "redux-devtools": "3.1.1",
     "redux-devtools-dock-monitor": "1.0.1",
     "redux-devtools-log-monitor": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-transform-hmr": "1.0.2",
     "redbox-react": "1.2.2",
     "redux": "3.3.1",
-    "redux-async-connect": "1.0.0-rc2",
+    "redux-async-connect": "0.1.13",
     "redux-devtools": "3.1.1",
     "redux-devtools-dock-monitor": "1.0.1",
     "redux-devtools-log-monitor": "1.0.4",

--- a/src/client.js
+++ b/src/client.js
@@ -9,13 +9,15 @@ import { render as renderDevtools } from './client/devtools';
 import middleware from 'universal-redux/middleware';
 import createRootClientComponent from 'universal-redux/rootClientComponent';
 
+import makeHelpers from 'universal-redux/asyncHelpers';
+
 const dest = document.getElementById('content');
 
 const store = createStore(middleware, window.__data);
 const devComponent = renderDevtools();
 
 // There is probably no need to be asynchronous here
-createRootClientComponent(store, __PROVIDERS__, devComponent)
+createRootClientComponent(store,  __PROVIDERS__, makeHelpers(), devComponent)
   .then((root) => {
     ReactDOM.render(root, dest);
 

--- a/src/client/providers/async-props.js
+++ b/src/client/providers/async-props.js
@@ -4,7 +4,13 @@ import { Router } from 'react-router';
 import getRoutes from 'universal-redux/routes';
 import AsyncProps from '../../vendor/async-props';
 
-export default function(store, devComponent) {
+/**
+ * @param store
+ * @param asyncHelpers - Ignored by async-props
+ * @param devComponent
+ * @returns {Promise.<Provider>}
+ */
+export default function(store, asyncHelpers, devComponent) {
   const root = (
     <Provider store={store} key="provider">
       <div>

--- a/src/client/providers/react-router.js
+++ b/src/client/providers/react-router.js
@@ -4,9 +4,9 @@ import { browserHistory } from 'react-router';
 import { ReduxAsyncConnect } from 'redux-async-connect';
 import getRoutes from 'universal-redux/routes';
 
-export default function(store) {
+export default function(store, asyncHelpers) {
   const component = (
-    <Router render={(props) => <ReduxAsyncConnect {...props} />} history={browserHistory}>
+    <Router render={(props) => <ReduxAsyncConnect {...props} helpers={ asyncHelpers }/>} history={browserHistory}>
       {getRoutes(store)}
     </Router>
   );

--- a/src/client/providers/redux-async-connect.js
+++ b/src/client/providers/redux-async-connect.js
@@ -2,11 +2,17 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import createRouter from './react-router';
 
-export default function(store, devComponent) {
+/**
+ * @param store - Redux store
+ * @param asyncHelpers - A resolved helpers object
+ * @param devComponent
+ * @returns {Promise.<Provider>}
+ */
+export default function(store, asyncHelpers, devComponent) {
   const root = (
     <Provider store={store} key="provider">
       <div>
-        {createRouter(store)}
+        {createRouter(store, asyncHelpers)}
         {devComponent}
       </div>
     </Provider>

--- a/src/client/root.js
+++ b/src/client/root.js
@@ -1,8 +1,14 @@
 import { includes } from 'lodash';
-import reduxAsyncConnectClient from './providers/redux-async-connect';
+import reduxAsyncConnectClient from './providers/redux-sync-connect';
 import asyncPropsClient from './providers/async-props';
 
-export default function(store, providers, devComponent) {
+/**
+ * @param {Object} store - Redux store
+ * @param {String[]} providers - Array of provider type strings ('async-props' | 'redux-async-connect')
+ * @param {Object} asyncHelpers - redux-async-connect helpers to be added to async connect
+ * @param {Component} devComponent - React component that is added at development time (redux dev tools)
+ */
+export default function(store, providers, asyncHelpers, devComponent) {
   let client = reduxAsyncConnectClient;
   if (includes(providers, 'async-props')) {
     client = asyncPropsClient;
@@ -11,5 +17,5 @@ export default function(store, providers, devComponent) {
     client = reduxAsyncConnectClient;
   }
 
-  return client(store, devComponent);
+  return client(store, asyncHelpers, devComponent);
 }

--- a/src/client/root.js
+++ b/src/client/root.js
@@ -1,5 +1,5 @@
 import { includes } from 'lodash';
-import reduxAsyncConnectClient from './providers/redux-sync-connect';
+import reduxAsyncConnectClient from './providers/redux-async-connect';
 import asyncPropsClient from './providers/async-props';
 
 /**

--- a/src/helpers/emptyFunction.js
+++ b/src/helpers/emptyFunction.js
@@ -1,0 +1,3 @@
+export default function () {
+
+}

--- a/src/helpers/emptyFunction.js
+++ b/src/helpers/emptyFunction.js
@@ -1,3 +1,4 @@
 export default function () {
 
+  return {};
 }

--- a/src/server/providers/redux-async-connect.js
+++ b/src/server/providers/redux-async-connect.js
@@ -12,7 +12,7 @@ import { ReduxAsyncConnect, loadOnServer } from 'redux-async-connect';
  */
 export default function(store, asyncHelpers, renderProps) {
   return new Promise((resolve, reject) => {
-    loadOnServer(renderProps, store)
+    loadOnServer(renderProps, store, asyncHelpers)
       .then(() => {
         const root = (
           <Provider store={store} key="provider">

--- a/src/server/providers/redux-async-connect.js
+++ b/src/server/providers/redux-async-connect.js
@@ -2,14 +2,22 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { ReduxAsyncConnect, loadOnServer } from 'redux-async-connect';
 
-export default function(store, renderProps) {
+/**
+ * Root component generation function
+ *
+ * @param store
+ * @param asyncHelpers
+ * @param renderProps
+ * @returns {Promise} A wrapping promise, which resolves after <loadOnServer> is completed
+ */
+export default function(store, asyncHelpers, renderProps) {
   return new Promise((resolve, reject) => {
     loadOnServer(renderProps, store)
       .then(() => {
         const root = (
           <Provider store={store} key="provider">
             <div>
-              <ReduxAsyncConnect {...renderProps} />
+              <ReduxAsyncConnect {...renderProps} helpers={asyncHelpers}/>
             </div>
           </Provider>
         );

--- a/src/server/providers/redux-async-connect.js
+++ b/src/server/providers/redux-async-connect.js
@@ -12,7 +12,7 @@ import { ReduxAsyncConnect, loadOnServer } from 'redux-async-connect';
  */
 export default function(store, asyncHelpers, renderProps) {
   return new Promise((resolve, reject) => {
-    loadOnServer({...renderProps, store})
+    loadOnServer(renderProps, store)
       .then(() => {
         const root = (
           <Provider store={store} key="provider">

--- a/src/server/providers/redux-async-connect.js
+++ b/src/server/providers/redux-async-connect.js
@@ -12,7 +12,7 @@ import { ReduxAsyncConnect, loadOnServer } from 'redux-async-connect';
  */
 export default function(store, asyncHelpers, renderProps) {
   return new Promise((resolve, reject) => {
-    loadOnServer(renderProps, store)
+    loadOnServer({...renderProps, store})
       .then(() => {
         const root = (
           <Provider store={store} key="provider">

--- a/src/server/renderer.js
+++ b/src/server/renderer.js
@@ -30,7 +30,8 @@ export default (projectConfig, projectToolsConfig) => {
     const middleware = config.redux.middleware ? require(path.resolve(config.redux.middleware)).default : [];
     const store = createStore(middleware);
     const routes = getRoutes(store);
-    const makeHelpers = config.reduxAsyncConnect.asyncHelpers ? require(path.resolve(config.reduxAsyncConnect.asyncHelpers)) : () => {return {test: 'server'}};
+    const makeHelpers = config.reduxAsyncConnect.helpers ? require(path.resolve(config.reduxAsyncConnect.helpers)).default : () => {return {test: 'server'}};
+
 
     if (__DISABLE_SSR__) {
       const content = html(config, tools.assets(), store, headers);

--- a/src/server/renderer.js
+++ b/src/server/renderer.js
@@ -30,6 +30,7 @@ export default (projectConfig, projectToolsConfig) => {
     const middleware = config.redux.middleware ? require(path.resolve(config.redux.middleware)).default : [];
     const store = createStore(middleware);
     const routes = getRoutes(store);
+    const makeHelpers = config.reduxAsyncConnect.asyncHelpers ? require(path.resolve(config.reduxAsyncConnect.asyncHelpers)) : () => {return {test: 'server'}};
 
     if (__DISABLE_SSR__) {
       const content = html(config, tools.assets(), store, headers);
@@ -44,7 +45,7 @@ export default (projectConfig, projectToolsConfig) => {
           console.error('ROUTER ERROR:', pretty.render(error));
           send(500, resolve);
         } else if (renderProps) {
-          rootServerComponent(store, renderProps, config.providers)
+          rootServerComponent(store, renderProps, makeHelpers(headers), config.providers)
             .then(({ root }) => {
               const content = html(config, tools.assets(), store, headers, root);
               send(200, content, resolve);

--- a/src/server/root.js
+++ b/src/server/root.js
@@ -2,7 +2,7 @@ import { includes } from 'lodash';
 import reduxAsyncConnectServer from './providers/redux-async-connect';
 import asyncPropsServer from './providers/async-props';
 
-export default function(store, renderProps, providers) {
+export default function(store, renderProps, asyncHelpers, providers) {
   let server = reduxAsyncConnectServer;
   if (includes(providers, 'async-props')) {
     server = asyncPropsServer;
@@ -10,5 +10,5 @@ export default function(store, renderProps, providers) {
   if (includes(providers, 'redux-async-connect')) {
     server = reduxAsyncConnectServer;
   }
-  return server(store, renderProps);
+  return server(store, asyncHelpers, renderProps);
 }


### PR DESCRIPTION
Opened up this pull request just to start discussion. It's not finished yet, but I'm curious of opinions about this approach.

Basic idea; in UR-jwt there is an example of a fetcher, that is wrapped in a piece of redux middleware. This works great if all the async behavior is wrapped in action creators. redux-async-connect provides a 'helpers' utility to for example get a fetcher into the async callback of asyncConnect. This PR implements a clients configurable helpers object which has access to the headers on the server side.

Following the discussions [here](https://github.com/bdefore/universal-redux/issues/50) I see everything is moving to redux-async-connect for UR even though there is some async-props leftovers in the code. To make authentication work in a redux-async-connect way I needed to use [this](https://github.com/Rezonans/redux-async-connect/blob/master/docs/API.MD#helpers) helpers utility.

How does it work;
config/universal-redux-config.js

```
{
  reduxAsyncConnect: { helpers: '/path/to/helpers' }
}
```

The file at that path (or index.js of directory at that path) should export a default function which creates the helpers object that is passed to the ReduxAsyncConnect component.
Something like this;

```
function (headers) {
return {
client: makeClient(headers)
}
}
```

In this example headers is the request headers on server side rendering and undefined on client side rendering.

I use this to pass the headers to axios, so that API calls have the same headers as the client specified. I'm aware that the initial render will not have a lot of application specific headers, but you can easily set them in express/koa middleware before rendering the server side logic.

For example I read the token from the cookie and set it to this.request.header['Authorization'], to be able to render the initial request with authenticated data. This makes authenticated calls on initial load possible through @asyncConnect
