### PR TITLE
Replaced redux-async-connect with fmp-redux-async-connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-transform-hmr": "1.0.4",
     "redbox-react": "1.2.10",
     "redux": "3.5.2",
-    "fmp-redux-async-connect": "0.1.14",
+    "fmp-redux-async-connect": "0.1.15",
     "redux-devtools": "3.3.1",
     "redux-devtools-dock-monitor": "1.1.1",
     "redux-devtools-log-monitor": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-transform-hmr": "1.0.4",
     "redbox-react": "1.2.10",
     "redux": "3.5.2",
-    "redux-async-connect": "0.1.13",
+    "fmp-redux-async-connect": "0.1.14",
     "redux-devtools": "3.3.1",
     "redux-devtools-dock-monitor": "1.1.1",
     "redux-devtools-log-monitor": "1.0.11",

--- a/src/client/providers/react-router.js
+++ b/src/client/providers/react-router.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Router } from 'react-router';
 import { browserHistory } from 'react-router';
-import { ReduxAsyncConnect } from 'redux-async-connect';
+import { ReduxAsyncConnect } from 'fmp-redux-async-connect';
 import getRoutes from 'universal-redux/routes';
 
 export default function(store) {

--- a/src/client/root.js
+++ b/src/client/root.js
@@ -7,7 +7,7 @@ export default function(store, providers, devComponent) {
   if (includes(providers, 'async-props')) {
     client = asyncPropsClient;
   }
-  if (includes(providers, 'redux-async-connect')) {
+  if (includes(providers, 'fmp-redux-async-connect')) {
     client = reduxAsyncConnectClient;
   }
 

--- a/src/server/providers/redux-async-connect.js
+++ b/src/server/providers/redux-async-connect.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { ReduxAsyncConnect, loadOnServer } from 'redux-async-connect';
+import { ReduxAsyncConnect, loadOnServer } from 'fmp-redux-async-connect';
 
 export default function(store, renderProps) {
   return new Promise((resolve, reject) => {

--- a/src/server/root.js
+++ b/src/server/root.js
@@ -7,7 +7,7 @@ export default function(store, renderProps, providers) {
   if (includes(providers, 'async-props')) {
     server = asyncPropsServer;
   }
-  if (includes(providers, 'redux-async-connect')) {
+  if (includes(providers, 'fmp-redux-async-connect')) {
     server = reduxAsyncConnectServer;
   }
   return server(store, renderProps);


### PR DESCRIPTION
Replaced `redux-async-connect` with `fmp-redux-async-connect`

Development on `redux-async-connect` has gone quiet.

Changes in `fmp-redux-async-connect` are:
- Add babel plugins to provide support for IE 10 and 9

[redux-async-connect pull request](https://github.com/Rezonans/redux-async-connect/pull/91)
